### PR TITLE
perf: 게시글 조회수 Redis 배치 처리

### DIFF
--- a/src/main/java/com/goteego/travel/domain/TravelPost.java
+++ b/src/main/java/com/goteego/travel/domain/TravelPost.java
@@ -128,6 +128,11 @@ public class TravelPost extends BaseEntity {
         this.viewCount++;
     }
 
+    // 조회수 업데이트
+    public void updateViewCount(Long viewCount) {
+        this.viewCount += viewCount;
+    }
+
     // 작성자 본인 확인
     public boolean isAuthor(Long userId) {
         return this.user.getId().equals(userId);

--- a/src/main/java/com/goteego/travel/dto/travel/BeforeTravelPostResponseDto.java
+++ b/src/main/java/com/goteego/travel/dto/travel/BeforeTravelPostResponseDto.java
@@ -32,13 +32,13 @@ public class BeforeTravelPostResponseDto {
     /**
      * TravelPost 엔티티를 DTO로 변환
      */
-    public static BeforeTravelPostResponseDto from(TravelPost travelPost, String nickname, Integer approvedParticipantCount) {
+    public static BeforeTravelPostResponseDto from(TravelPost travelPost, String nickname, Integer approvedParticipantCount, Long viewCount) {
         return BeforeTravelPostResponseDto.builder()
                 .travelPostId(travelPost.getId())
                 .title(travelPost.getTitle())
                 .content(travelPost.getContent())
                 .location(travelPost.getLocation().name())
-                .viewCount(travelPost.getViewCount())
+                .viewCount(viewCount)
                 .startTime(travelPost.getStartTime().toString())
                 .endTime(travelPost.getEndTime().toString())
                 .author(createAuthorDto(travelPost.getUser(), nickname))

--- a/src/main/java/com/goteego/travel/dto/travel/TravelPostContext.java
+++ b/src/main/java/com/goteego/travel/dto/travel/TravelPostContext.java
@@ -5,5 +5,6 @@ import com.goteego.travel.domain.TravelPost;
 public record TravelPostContext(
         TravelPost tp,
         Long currentUserId,
-        String nickname) {
+        String nickname,
+        Long viewCount) {
 }

--- a/src/main/java/com/goteego/travel/service/ScheduleService.java
+++ b/src/main/java/com/goteego/travel/service/ScheduleService.java
@@ -68,7 +68,8 @@ public class ScheduleService {
                     return BeforeTravelPostResponseDto.from(
                             tp,
                             tp.getUser().getNickname(),
-                            approvedParticipantCount
+                            approvedParticipantCount,
+                            tp.getViewCount()
                     );
                 })
                 .collect(Collectors.toList());

--- a/src/main/java/com/goteego/travel/service/TravelPostService.java
+++ b/src/main/java/com/goteego/travel/service/TravelPostService.java
@@ -23,6 +23,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -30,6 +31,8 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+
+import static java.util.stream.Collectors.toList;
 
 /**
  * 여행 게시글 서비스
@@ -47,6 +50,7 @@ public class TravelPostService {
     private final RecommendationService recommendationService;
     private final UserService userService;
     private final ChatRoomService chatRoomService;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     /**
      * 여행 게시글 목록 조회
@@ -101,7 +105,7 @@ public class TravelPostService {
                         Long approvedCount = participationApplicationRepository
                                 .countByTravelPostIdAndStatus(ctx.tp().getId(), ParticipationStatus.APPROVED);
                         int approvedParticipantCount = approvedCount != null ? approvedCount.intValue() : 0;
-                        return BeforeTravelPostResponseDto.from(ctx.tp(), ctx.nickname(), approvedParticipantCount);
+                        return BeforeTravelPostResponseDto.from(ctx.tp(), ctx.nickname(), approvedParticipantCount, ctx.viewCount());
                     }
             );
             return TravelPostResponseWrapper.before(content, pageInfo);
@@ -126,8 +130,16 @@ public class TravelPostService {
         TravelPost travelPost = travelPostRepository.findById(postId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.POST_NOT_FOUND));
 
-        // 조회수 증가
-        travelPost.incrementViewCount();
+        // [1] Redis에서 조회수 증가
+        String viewCountKey = "post:view:" + postId;
+        Long viewCount = redisTemplate.opsForValue().increment(viewCountKey);
+
+        // [2] 30번 조회할 때 마다 DB 반영
+        if (viewCount % 30 == 0) { //
+            travelPost.updateViewCount(viewCount);
+            travelPostRepository.save(travelPost);
+        }
+
         return TravelPostDetailResponseDto.from(travelPost);
     }
 
@@ -389,8 +401,25 @@ public class TravelPostService {
 
         // DTO 변환
         return sortedPosts.stream()
-                .map(tp -> converter.apply(new TravelPostContext(tp, currentUserId, tp.getUser().getNickname())))
+                .map(tp -> {
+                    // Redis 조회수 확인
+                    Long redisViewCounts = getViewCountFromRedis(tp.getId());
+                    TravelPostContext travelPostContext = new TravelPostContext(tp, currentUserId, tp.getUser().getNickname(),
+                                                                    redisViewCounts != null ? redisViewCounts : tp.getViewCount());
+                    return converter.apply(travelPostContext);
+                })
                 .toList();
+    }
+
+    private Long getViewCountFromRedis(Long postId) {
+        try {
+            String key = "post:view:" + postId;
+            Object value = redisTemplate.opsForValue().get(key);
+            return value != null ? Long.parseLong(value.toString()) : null;
+        } catch (Exception e) {
+            log.warn("Redis 조회수 조회 실패 postId: {}", postId, e);
+            return null;
+        }
     }
 
     /**

--- a/src/main/resources/static/post.html
+++ b/src/main/resources/static/post.html
@@ -44,13 +44,21 @@
                 <label>페이지 크기:</label>
                 <input type="number" id="test-pageSize" value="5" min="1" max="20">
             </div>
+            <!-- 정렬 버튼 추가 -->
+            <div class="form-group">
+                <label>정렬 기준:</label>
+                <div class="sort-buttons">
+                    <button onclick="getTravelPosts('recent')" class="sort-button active" id="sort-recent">최신순</button>
+                    <button onclick="getTravelPosts('view')" class="sort-button" id="sort-view">조회순</button>
+                </div>
+            </div>
         </div>
-        <button onclick="testGetTravelPosts()" class="test">게시글 목록 테스트</button>
-        <button onclick="testGetCurrentUser()" class="test">내 정보 테스트</button>
-        <button onclick="testGetMySchedules()" class="test">내 일정 테스트</button>
-        <button onclick="testCreateTravelPost()" class="test">게시글 작성 테스트</button>
-        <button onclick="testJoinTravelPost()" class="test">참여 신청 테스트</button>
-        <pre id="test-result"></pre>
+<!--        <button onclick="testGetTravelPosts()" class="test">게시글 목록 테스트</button>-->
+<!--        <button onclick="testGetCurrentUser()" class="test">내 정보 테스트</button>-->
+<!--        <button onclick="testGetMySchedules()" class="test">내 일정 테스트</button>-->
+<!--        <button onclick="testCreateTravelPost()" class="test">게시글 작성 테스트</button>-->
+<!--        <button onclick="testJoinTravelPost()" class="test">참여 신청 테스트</button>-->
+<!--        <pre id="test-result"></pre>-->
     </div>
 
     <!-- 여행 게시판 API 섹션 -->
@@ -161,6 +169,7 @@
     // 전역 변수 (테스트용)
     let currentPostType = 'BEFORE';
     let currentPageSize = 10;
+    let currentSort = 'recent';
 
     function getAuthHeaders() {
         const accessToken = getCookie('accessToken');
@@ -321,20 +330,65 @@
     }
 
     // ===== 여행 게시판 API =====
-    async function getTravelPosts() {
+    // async function getTravelPosts() {
+    //     const postType = document.getElementById('postType-select').value;
+    //     const pageSize = document.getElementById('pageSize-input').value;
+    //
+    //     console.log('getTravelPosts 호출됨 - postType:', postType, 'pageSize:', pageSize);
+    //
+    //     try {
+    //         const res = await axios.get(`/api/travel-posts?postType=${postType}&page=0&size=${pageSize}`, {headers: getAuthHeaders()});
+    //         console.log('게시글 목록 API 응답:', res.data);
+    //         displayTravelPosts(res.data, postType);
+    //     } catch(e) {
+    //         console.error('게시글 목록 조회 실패:', e);
+    //         let errorMessage = '알 수 없는 오류가 발생했습니다.';
+    //
+    //         if (e.response) {
+    //             if (e.response.status === 401) {
+    //                 errorMessage = '로그인이 필요합니다. Google 계정으로 로그인해주세요.';
+    //             } else if (e.response.status === 403) {
+    //                 errorMessage = '접근 권한이 없습니다.';
+    //             } else if (e.response.data && e.response.data.message) {
+    //                 errorMessage = e.response.data.message;
+    //             } else {
+    //                 errorMessage = `서버 오류 (${e.response.status}): ${e.message}`;
+    //             }
+    //         } else if (e.request) {
+    //             errorMessage = '서버에 연결할 수 없습니다. 서버가 실행 중인지 확인해주세요.';
+    //         } else {
+    //             errorMessage = e.message;
+    //         }
+    //
+    //         document.getElementById('travel-result').innerHTML = `<div class="error-message">❌ 에러: ${errorMessage}</div>`;
+    //     }
+    // }
+
+    async function getTravelPosts(sortType) {
+        // 정렬 타입이 전달되면 업데이트
+        if (sortType) {
+            currentSort = sortType;
+
+            // 정렬 버튼 활성화 상태 업데이트
+            document.querySelectorAll('.sort-button').forEach(btn => {
+                btn.classList.remove('active');
+            });
+            document.getElementById(`sort-${sortType}`).classList.add('active');
+        }
+
         const postType = document.getElementById('postType-select').value;
         const pageSize = document.getElementById('pageSize-input').value;
-        
-        console.log('getTravelPosts 호출됨 - postType:', postType, 'pageSize:', pageSize);
-        
+
         try {
-            const res = await axios.get(`/api/travel-posts?postType=${postType}&page=0&size=${pageSize}`, {headers: getAuthHeaders()});
+            const res = await axios.get(`/api/travel-posts?postType=${postType}&page=0&size=${pageSize}&sort=${currentSort}`, {
+                headers: getAuthHeaders()
+            });
             console.log('게시글 목록 API 응답:', res.data);
             displayTravelPosts(res.data, postType);
-        } catch(e) { 
+        } catch(e) {
             console.error('게시글 목록 조회 실패:', e);
             let errorMessage = '알 수 없는 오류가 발생했습니다.';
-            
+
             if (e.response) {
                 if (e.response.status === 401) {
                     errorMessage = '로그인이 필요합니다. Google 계정으로 로그인해주세요.';
@@ -350,7 +404,7 @@
             } else {
                 errorMessage = e.message;
             }
-            
+
             document.getElementById('travel-result').innerHTML = `<div class="error-message">❌ 에러: ${errorMessage}</div>`;
         }
     }


### PR DESCRIPTION


## ✨ 변경 내용
- 게시글 상세조회 시, redis에서만 계속 증가되며, 30의 배수마다 postgreSQL에 쿼리 수행하도록 변경
- 게시글 목록 조회 시, redis에 저장된 조회수를 기반으로 반환하도록 변경


## 💬 기타 사항
- 조회순 게시글을 redis 캐싱하는것은 정합성 문제 + 성능에 영향이 미비해서 실제로 추가할지 의논 필요
