### PR TITLE
refactor: @Qualifier로 채팅/알림 토픽 분리 처리 개선

### DIFF
--- a/src/main/java/com/goteego/chat/service/ChatService.java
+++ b/src/main/java/com/goteego/chat/service/ChatService.java
@@ -17,6 +17,7 @@ import com.goteego.user.dto.UserDto;
 import com.goteego.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.redis.listener.ChannelTopic;
@@ -25,7 +26,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Slf4j
 public class ChatService {
@@ -36,6 +36,18 @@ public class ChatService {
     private final RedisPublisher redisPublisher;
     private final ChannelTopic chatTopic;
     private final ChannelTopic notificationTopic;
+
+    public ChatService(ChatMessageRepository chatMessageRepository, UserService userService,
+                       ChatRoomRepository chatRoomRepository, RedisPublisher redisPublisher,
+                       @Qualifier("chatTopic") ChannelTopic chatTopic,
+                       @Qualifier("notificationTopic") ChannelTopic notificationTopic) {
+        this.chatMessageRepository = chatMessageRepository;
+        this.userService = userService;
+        this.chatRoomRepository = chatRoomRepository;
+        this.redisPublisher = redisPublisher;
+        this.chatTopic = chatTopic;
+        this.notificationTopic = notificationTopic;
+    }
 
     /**********************
      * 1:1 채팅 메시지 전송 /

--- a/src/main/java/com/goteego/chat/service/redis/RedisSubscriber.java
+++ b/src/main/java/com/goteego/chat/service/redis/RedisSubscriber.java
@@ -8,12 +8,12 @@ import com.goteego.chat.dto.message.transfer.DirectMessageTransferDto;
 import com.goteego.chat.dto.message.transfer.NotificationTransferDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
 @Service
-@RequiredArgsConstructor
 @Slf4j
 public class RedisSubscriber {
 
@@ -23,6 +23,15 @@ public class RedisSubscriber {
     // ChannelTopic을 주입받아 토픽 이름을 비교하는 데 사용합니다.
     private final ChannelTopic chatTopic;
     private final ChannelTopic notificationTopic;
+
+    public RedisSubscriber(ObjectMapper objectMapper, SimpMessagingTemplate messagingTemplate,
+                           @Qualifier("chatTopic") ChannelTopic chatTopic,
+                           @Qualifier("notificationTopic") ChannelTopic notificationTopic) {
+        this.objectMapper = objectMapper;
+        this.messagingTemplate = messagingTemplate;
+        this.chatTopic = chatTopic;
+        this.notificationTopic = notificationTopic;
+    }
 
     private static final String DIRECT_MESSAGE_PATH = "/queue/messages";
     private static final String GROUP_MESSAGE_PATH = "/sub/chat/room/";

--- a/src/main/java/com/goteego/global/redis/RedisConfig.java
+++ b/src/main/java/com/goteego/global/redis/RedisConfig.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.goteego.chat.service.redis.RedisSubscriber;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
@@ -82,6 +83,7 @@ public class RedisConfig {
 
     // Pub/Sub에서 사용할 채팅 관련 공용 채널 정의
     @Bean
+    @Qualifier("chatTopic")
     public ChannelTopic chatTopic() {
         // 여기서는 모든 채팅 메시지를 "chat"이라는 단일 토픽으로 처리
         return new ChannelTopic("chat");
@@ -89,6 +91,7 @@ public class RedisConfig {
 
     // Pub/Sub에서 사용할 알림 관련 공용 채널 정의
     @Bean
+    @Qualifier("notificationTopic")
     public ChannelTopic notificationTopic() {
         return new ChannelTopic("notification");
     }

--- a/src/main/java/com/goteego/global/security/auth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/goteego/global/security/auth/OAuth2SuccessHandler.java
@@ -58,9 +58,9 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         log.info("✅ [OAuth2Success] Token 쿠키로 전송 완료");
         // ✅ 리디렉션
 //        response.sendRedirect("/dashboard.html");
-        response.sendRedirect("/post.html");
+//        response.sendRedirect("/post.html");
 
         // ✅ 프론트엔드로 리다이렉트
-//        response.sendRedirect(frontendUrl);
+        response.sendRedirect(frontendUrl);
     }
 }

--- a/src/main/resources/static/chat.html
+++ b/src/main/resources/static/chat.html
@@ -10,54 +10,6 @@
     <script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
     <script src="/js/shared-websocket.js"></script>
     <script src="/js/common.js"></script>
-    <style>
-        .loader {
-            padding: 10px;
-            text-align: center;
-            color: #666;
-        }
-        .chat-messages {
-            overflow-y: auto;
-            /* 화면 높이에 맞게 조절 */
-            height: calc(100vh - 200px);
-            padding: 10px;
-            display: flex;
-            flex-direction: column;
-        }
-        .message {
-            margin-bottom: 10px;
-            padding: 8px 12px;
-            background: #f1f0f0;
-            border-radius: 18px;
-            max-width: 60%;
-            word-wrap: break-word;
-        }
-        .message.sent {
-            align-self: flex-end;
-            background-color: #007bff;
-            color: white;
-        }
-        .message.received {
-            align-self: flex-start;
-            background-color: #e9e9eb;
-        }
-        .message-sender {
-            font-size: 0.8em;
-            font-weight: bold;
-            margin-bottom: 4px;
-        }
-        .message-timestamp {
-            font-size: 0.7em;
-            color: #888;
-            margin-left: 8px;
-        }
-        .no-messages {
-            text-align: center;
-            color: #999;
-            padding: 20px;
-            margin: auto;
-        }
-    </style>
 </head>
 <body>
 <div class="chat-container">

--- a/src/main/resources/static/css/chat.css
+++ b/src/main/resources/static/css/chat.css
@@ -126,3 +126,50 @@ body {
     padding: 10px;
     color: #999;
 }
+
+.loader {
+    padding: 10px;
+    text-align: center;
+    color: #666;
+}
+.chat-messages {
+    overflow-y: auto;
+    /* 화면 높이에 맞게 조절 */
+    height: calc(100vh - 200px);
+    padding: 10px;
+    display: flex;
+    flex-direction: column;
+}
+.message {
+    margin-bottom: 10px;
+    padding: 8px 12px;
+    background: #f1f0f0;
+    border-radius: 18px;
+    max-width: 60%;
+    word-wrap: break-word;
+}
+.message.sent {
+    align-self: flex-end;
+    background-color: #007bff;
+    color: white;
+}
+.message.received {
+    align-self: flex-start;
+    background-color: #e9e9eb;
+}
+.message-sender {
+    font-size: 0.8em;
+    font-weight: bold;
+    margin-bottom: 4px;
+}
+.message-timestamp {
+    font-size: 0.7em;
+    color: #888;
+    margin-left: 8px;
+}
+.no-messages {
+    text-align: center;
+    color: #999;
+    padding: 20px;
+    margin: auto;
+}


### PR DESCRIPTION
## ✨ 변경 내용
- Redis Pub/Sub에서 채팅과 알림 메시지 구분을 위해 @Qualifier 도입
- chatTopic과 notificationTopic을 명시적으로 구분하여 주입하도록 변경
- RedisConfig에 Qualifier가 지정된 별도 ChannelTopic 빈 정의
- RedisSubscriber에서 토픽 타입에 따라 메시지 처리 로직 분기
- ChatService에서 각 목적에 맞는 토픽으로 메시지 발행하도록 수정