### PR TITLE
fix(config): 데이터베이스 Repository 스캔 충돌 해결

### DIFF
--- a/src/main/java/com/goteego/GotEEgoApplication.java
+++ b/src/main/java/com/goteego/GotEEgoApplication.java
@@ -2,9 +2,10 @@ package com.goteego;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = MongoDataAutoConfiguration.class)
 @EnableJpaAuditing
 public class GotEEgoApplication {
 

--- a/src/main/java/com/goteego/global/db/MongoConfig.java
+++ b/src/main/java/com/goteego/global/db/MongoConfig.java
@@ -1,0 +1,15 @@
+package com.goteego.global.db;
+
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+
+@Configuration
+@EnableMongoRepositories(
+        basePackages = "com.goteego.chat.repository",
+        includeFilters = @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = MongoRepository.class)
+)
+public class MongoConfig {
+}


### PR DESCRIPTION
JPA, MongoDB, Redis를 함께 사용할 때 발생하는 Repository 스캔 모호성 문제를 해결

- MongoDataAutoConfiguration을 제외하여 자동 설정 충돌 방지
- @EnableMongoRepositories와 필터를 사용하여 몽고DB Repository 스캔 경로를 명시적으로 지정
