### PR TITLE
뱃지 이미지 s3 업로드 앱 실행 시

### DIFF
--- a/src/main/java/com/goteego/badge/domain/ImageResizeLambda.java
+++ b/src/main/java/com/goteego/badge/domain/ImageResizeLambda.java
@@ -1,0 +1,117 @@
+//package com.goteego.badge.domain;
+//
+//import com.amazonaws.services.lambda.runtime.Context;
+//import com.amazonaws.services.lambda.runtime.RequestHandler;
+//import com.amazonaws.services.lambda.runtime.events.S3Event;
+//import software.amazon.awssdk.core.sync.RequestBody;
+//import software.amazon.awssdk.regions.Region;
+//import software.amazon.awssdk.services.s3.S3Client;
+//import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+//import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+//
+//import javax.imageio.ImageIO;
+//import java.awt.*;
+//import java.awt.image.BufferedImage;
+//import java.io.*;
+//
+//public class ImageResizeLambda implements RequestHandler<S3Event, String> {
+//
+//    private final S3Client s3Client = S3Client.builder()
+//            .region(Region.of("ap-northeast-2")) // 실제 S3 버킷 리전으로 변경
+//            .build();
+//
+//    @Override
+//    public String handleRequest(S3Event event, Context context) {
+//
+//        String bucket = null;
+//        try {
+//            // 이벤트 레코드 여러 개 처리
+//            for (var record : event.getRecords()) {
+//                bucket = record.getS3().getBucket().getName();
+//
+//                String keyRaw = record.getS3().getObject().getKey();
+//                String key = java.net.URLDecoder.decode(keyRaw, "UTF-8");
+//                context.getLogger().log("Received S3 key: " + key);
+//
+//                // badges/ 경로의 이벤트가 아닐경우 스킵
+//                if (!key.startsWith("badges/")) {
+//                    context.getLogger().log("Skipping non-badges key: " + key);
+//                    continue;
+//                }
+//
+//                // 원본 이미지 다운로드
+//                InputStream originalImageStream = s3Client.getObject(
+//                        GetObjectRequest.builder()
+//                                .bucket(bucket)
+//                                .key(key)
+//                                .build());
+//
+//                BufferedImage originalImage = ImageIO.read(originalImageStream);
+//                originalImageStream.close();
+//
+//                // 리사이즈 사이즈 정의
+//                Dimension smallSize = new Dimension(100, 100);
+//                Dimension mediumSize = new Dimension(300, 300);
+//
+//                // 리사이즈 및 업로드
+//                resizeAndUpload(bucket, key, originalImage, smallSize, "thumb-small/");
+//                resizeAndUpload(bucket, key, originalImage, mediumSize, "thumb-medium/");
+//            }
+//
+//            return "Success resizing all images.";
+//
+//        } catch (Exception e) {
+//            context.getLogger().log("Error: " + e.getMessage());
+//            e.printStackTrace();
+//            return "Error resizing images for bucket: " + bucket;
+//        }
+//    }
+//
+//    private void resizeAndUpload(String bucket, String originalKey, BufferedImage originalImage, Dimension targetSize, String prefix) throws IOException {
+//        // 비율 유지하며 리사이즈
+//        BufferedImage resizedImage = resizeImage(originalImage, targetSize.width, targetSize.height);
+//
+//        // 이미지 바이트로 변환
+//        ByteArrayOutputStream os = new ByteArrayOutputStream();
+//        ImageIO.write(resizedImage, "png", os);
+//        byte[] buffer = os.toByteArray();
+//
+//        // 새 파일명 생성 (예: badges/thumb-small/original.png)
+//        String fileName = originalKey.substring(originalKey.lastIndexOf('/') + 1);
+//        String newKey = "badges/" + prefix + fileName;
+//
+//        // S3 업로드
+//        s3Client.putObject(
+//                PutObjectRequest.builder()
+//                        .bucket(bucket)
+//                        .key(newKey)
+//                        .contentType("image/png")
+//                        .contentLength((long) buffer.length)
+//                        .build(),
+//                RequestBody.fromBytes(buffer)
+//        );
+//    }
+//
+//    private BufferedImage resizeImage(BufferedImage originalImage, int targetWidth, int targetHeight) {
+//        // 원본 비율 유지
+//        int originalWidth = originalImage.getWidth();
+//        int originalHeight = originalImage.getHeight();
+//
+//        float widthRatio = (float) targetWidth / originalWidth;
+//        float heightRatio = (float) targetHeight / originalHeight;
+//        float ratio = Math.min(widthRatio, heightRatio);
+//
+//        int newWidth = Math.round(originalWidth * ratio);
+//        int newHeight = Math.round(originalHeight * ratio);
+//
+//        Image tmp = originalImage.getScaledInstance(newWidth, newHeight, Image.SCALE_SMOOTH);
+//        BufferedImage resized = new BufferedImage(newWidth, newHeight, BufferedImage.TYPE_INT_ARGB);
+//
+//        Graphics2D g2d = resized.createGraphics();
+//        g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+//        g2d.drawImage(tmp, 0, 0, null);
+//        g2d.dispose();
+//
+//        return resized;
+//    }
+//}

--- a/src/main/java/com/goteego/badge/service/BadgeService.java
+++ b/src/main/java/com/goteego/badge/service/BadgeService.java
@@ -16,22 +16,33 @@ import com.goteego.feed.repository.FeedRepository;
 import com.goteego.global.domain.enumerate.Location;
 import com.goteego.global.error.exception.ErrorCode;
 import com.goteego.global.error.exception.NotFoundException;
+import com.goteego.global.s3.S3Directory;
+import com.goteego.global.s3.S3Service;
 import jakarta.annotation.PostConstruct;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-
+import org.springframework.web.multipart.MultipartFile;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class BadgeService {
 
     private final UserBadgeRepository userBadgeRepository;
     private final BadgeRepository badgeRepository;
     private final FeedRepository feedRepository;
     private final LandmarkBadgeRequestReposiroty landmarkBadgeRequestReposiroty;
+    private final S3Service s3Service;
 
     public List<BadgeResponse> getBadgesByUserId(Long userId) {
         List<UserBadge> userBadges = userBadgeRepository.findByUserId(userId);
@@ -68,9 +79,61 @@ public class BadgeService {
                 BadgeCode.LANDMARK_SEORAKSAN,
                 BadgeCode.LANDMARK_JEONJUHANOK);
 
-        for (BadgeCode code : badgeCodes) {
-            Badge badge = Badge.builder().category(BadgeCategory.LANDMARK).code(code).imgUrl("https://example.com/icon.png").build();
-            badgeRepository.save(badge);
+        List<String> googleFileIds = List.of(
+                "1A4_upRjZwtPNI19J2QS5_RZ3N6dIToug",
+                "1oQXqa5fJp4QHEqNqxT-BOhsx6gkNfmVr",
+                "1l_mCCvFwhcLNBVmAJJQg6DwsH7F9khll",
+                "1pFQSAN18-nVdgnViKnRmp3hJbJ6UBQzC",
+                "14f8nNZi90LCsVSa64ZXvKeTfydnGj_CV",
+                "1hP_6E62GDX_is0RmUi-jlA97aUMbqC3_",
+                "1hUZmItVGoyCbDhw75eT-lVBcaX8t5mRm",
+                "1N2J1lhkpuCzghiA6HCGNKLZL1mIv7ZsO",
+                "11l8Mveo4wre1uY5Um0wSuyuMng-B3UVG",
+                "1SywQdxcR12_VFl24jLk81oGq4nn87YM6"
+        );
+
+
+        for (int i = 0; i < badgeCodes.size(); i++) {
+            try (InputStream inputStream = downloadImageFromGoogleDrive(googleFileIds.get(i))) {
+                String fileName = badgeCodes.get(i).name().toLowerCase() + ".png";
+                String key = S3Directory.BADGES + "/" + fileName;
+
+                // InputStream 크기 측정
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                inputStream.transferTo(baos);
+                byte[] bytes = baos.toByteArray();
+
+                try (InputStream uploadStream = new ByteArrayInputStream(bytes)) {
+                    String uploadedImageUrl = s3Service.uploadFile(uploadStream, bytes.length, "image/png", key);
+
+                    Badge badge = Badge.builder()
+                            .category(BadgeCategory.LANDMARK)
+                            .code(badgeCodes.get(i))
+                            .imgUrl(uploadedImageUrl)
+                            .build();
+
+                    badgeRepository.save(badge);
+                }
+
+            } catch (IOException e) {
+                log.error("이미지 다운로드 또는 업로드 실패: " + badgeCodes.get(i), e);
+            }
+        }
+    }
+
+
+    public InputStream downloadImageFromGoogleDrive(String fileId) throws IOException {
+        String downloadUrl = "https://drive.google.com/uc?export=download&id=" + fileId;
+        URL url = new URL(downloadUrl);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("GET");
+        conn.setDoInput(true);
+
+        int responseCode = conn.getResponseCode();
+        if (responseCode == HttpURLConnection.HTTP_OK) {
+            return conn.getInputStream();
+        } else {
+            throw new IOException("Failed to download file from Google Drive. HTTP code: " + responseCode);
         }
     }
 

--- a/src/main/java/com/goteego/global/s3/S3Directory.java
+++ b/src/main/java/com/goteego/global/s3/S3Directory.java
@@ -4,6 +4,7 @@ public final class S3Directory {
     public static final String FEEDS = "feeds";
     public static final String TRAVEL_POSTS = "travel-posts";
     public static final String PROFILES = "profiles";
+    public static final String BADGES = "badges";
 
     private S3Directory() {
         // 인스턴스화 방지

--- a/src/main/java/com/goteego/global/s3/S3Service.java
+++ b/src/main/java/com/goteego/global/s3/S3Service.java
@@ -12,6 +12,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.*;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
@@ -75,6 +76,28 @@ public class S3Service {
         }
     }
 
+    /**
+     * 파일 업로드 InputStream
+     */
+    public String uploadFile(InputStream inputStream, long contentLength, String contentType, String key) {
+        try {
+            PutObjectRequest request = PutObjectRequest.builder()
+                    .bucket(s3Properties.getBucketName())
+                    .key(key)
+                    .contentType(contentType)
+                    .build();
+
+            s3Client.putObject(request, RequestBody.fromInputStream(inputStream, contentLength));
+
+            return generateFileUrl(key);
+        } catch (S3Exception e) {
+            log.error("❌ [S3] 업로드 실패", e);
+            throw new S3Exception(ErrorCode.S3_UPLOAD_FAILED);
+        } catch (Exception e) {
+            log.error("❌ [S3] 알 수 없는 오류", e);
+            throw new S3Exception(ErrorCode.S3_UNKNOWN_ERROR);
+        }
+    }
     /**
      * ✅ 단일 파일 삭제
      */


### PR DESCRIPTION
1. 뱃지 이미지 s3 업로드 (앱 실행시)
2. 람다이용 리사이즈 이미지 생성 (개인계정 테스트 완료. 진행할지 모르겠어서 일단 주석처리)

## ✨ 변경 내용
- 예: 여행 일정 생성 API 구현

---

## 📌 관련 이슈
- resolved: #이슈번호

---

## ✅ 체크리스트
- [ ] 기능이 정상 동작함
- [ ] 불필요한 코드/콘솔 제거함
- [ ] 스타일/포맷팅 문제 없음

---

## 💬 기타 사항
-
